### PR TITLE
Address #80 - Remove double "command detected" statement

### DIFF
--- a/basement_bot/base/advanced.py
+++ b/basement_bot/base/advanced.py
@@ -339,7 +339,7 @@ class AdvancedBot(DataBot):
             ctx.guild, key="logging_channel"
         )
 
-        sliced_content = f"Command detected: `{ctx.message.content[:100]}`"
+        sliced_content = ctx.message.content[:100]
         message = f"Command detected: {sliced_content}"
 
         await self.logger.info(


### PR DESCRIPTION
Make it so command detected: is displayed twice
Fixed issue #80 