### PR TITLE
Rule extension fixes

### DIFF
--- a/techsupport_bot/extensions/rules.py
+++ b/techsupport_bot/extensions/rules.py
@@ -92,6 +92,8 @@ class Rules(base.BaseCog):
         first = True
 
         numbers = []
+        already_done = []
+        errors = []
 
         # Splits content string, and adds each item to number list
         # Catches ValueError when no number is specified
@@ -114,15 +116,14 @@ class Rules(base.BaseCog):
                 await ctx.send_deny_embed("There are no rules for this server")
                 return
             rules = rules_data.get("rules")
+            if number in already_done:
+                continue
 
             try:
                 rule = rules[number - 1]
             except IndexError:
-                rule = None
-
-            if not rule:
-                await ctx.send_deny_embed(f"Rule number {number} doesn't exist")
-                return
+                errors.append(number)
+                continue
 
             embed = RuleEmbed(
                 title=f"Rule {number}", description=rule.get("description", "None")
@@ -139,6 +140,11 @@ class Rules(base.BaseCog):
                 first = False
             else:
                 await ctx.send(embed=embed, mention_author=False)
+
+            already_done.append(number)
+
+        for error in errors:
+            await ctx.send_deny_embed(f"Rule number {error} doesn't exist")
 
     @commands.guild_only()
     @rule_group.command(


### PR DESCRIPTION
Calling `.rule get` with an invalid rule number doesn't stop outputting the rest of valid numbers, any errors generated will get outputted at the end. A rule also can't get called twice now.

e.g. `.rule get 1,2,2,69420,3` 
Rule 1 > Rule 2 > Rule 3 > Rule 69420 error

Fixes #272 and #273 