### PR TITLE
Added handling for no note_readers setup

### DIFF
--- a/techsupport_bot/extensions/who.py
+++ b/techsupport_bot/extensions/who.py
@@ -75,13 +75,22 @@ class Who(base.BaseCog):
         """Checks whether invoker can read notes. If at least one reader
         role is not set, all members can read notes."""
         config = await interaction.client.get_context_config(interaction)
-        if readers := config.extensions.who.note_readers.value:
-            roles = (
-                discord.utils.get(interaction.guild.roles, name=reader)
-                for reader in readers
-            )
-            return any((role in interaction.user.roles for role in roles))
-        return True
+        reader_roles = config.extensions.who.note_readers.value
+
+        if not reader_roles:
+            message="There aren't any `note_readers` roles set in the config!"
+            embed = auxiliary.prepare_deny_embed(message=message)
+
+            await interaction.response.send_message(embed=embed, ephemeral=True)
+
+            raise commands.CommandError(message)
+    
+        roles = (
+            discord.utils.get(interaction.guild.roles, name=role)
+            for role in reader_roles
+        )
+
+        return any((role in interaction.user.roles for role in roles))
 
     @app_commands.check(is_reader)
     @app_commands.command(


### PR DESCRIPTION
Instead of an "Application did not respond" error now throws the following

![image](https://github.com/r-Techsupport/TechSupportBot/assets/100243410/328e6236-cccf-40d2-975a-d93c42af0155)
