### PR TITLE
Quickly pin pyyamls cython version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ COPY Pipfile .
 COPY Pipfile.lock .
 
 RUN pip install --no-cache-dir pipenv==$(sed -nE 's/pipenv = "==(.*)"/\1/p' Pipfile)
-RUN pip install "cython<3.0" pyyaml --no-build-isolation
+RUN pip install --no-cache-dir "cython<3.0" pyyaml --no-build-isolation
 RUN pipenv install --system
 
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ COPY Pipfile .
 COPY Pipfile.lock .
 
 RUN pip install --no-cache-dir pipenv==$(sed -nE 's/pipenv = "==(.*)"/\1/p' Pipfile)
+RUN pip install "cython<3.0" pyyaml --no-build-isolation
 RUN pipenv install --system
 
 COPY . .


### PR DESCRIPTION
Due to cython 3.0.0 being released, pyyaml is broken

Until this is fixed, this new line in the DockerFile must stay