### PR TITLE
Remove battlenet from default config

### DIFF
--- a/config.default.yml
+++ b/config.default.yml
@@ -31,8 +31,6 @@ main:
         spotify_client:
         spotify_key:
         github:
-        battlenet_client:
-        battlenet_key:
         openai:
         dumpdbg_api:
     logging:


### PR DESCRIPTION
This got left after the warcraft extension was removed, so we don't need this anymore