### PR TITLE
protect|logger: account for file size limit

### DIFF
--- a/techsupport_bot/extensions/logger.py
+++ b/techsupport_bot/extensions/logger.py
@@ -105,8 +105,17 @@ class Logger(base.MatchCog):
             )
             return
 
-        attachments = []
+        attachments: list[discord.File] = []
         if ctx.message.attachments:
-            attachments = [await attch.to_file() for attch in ctx.message.attachments]
+            total_attachment_size = 0
+            for attch in ctx.message.attachments:
+                if (
+                    total_attachment_size := total_attachment_size + attch.size
+                ) <= ctx.filesize_limit:
+                    attachments.append(await attch.to_file())
+            if (lf := len(ctx.message.attachments) - len(attachments)) != 0:
+                await self.bot.logger.info(
+                    f"Did not reupload {lf} file(s) due to file size limit."
+                )
 
         await channel.send(embed=LogEmbed(context=ctx), files=attachments[:10])

--- a/techsupport_bot/extensions/protect.py
+++ b/techsupport_bot/extensions/protect.py
@@ -287,16 +287,25 @@ class Protector(base.MatchCog):
         """Method to set up the number of max lines."""
         return int(max_length / self.CHARS_PER_NEWLINE) + 1
 
-    async def handle_length_alert(self, config, ctx, content):
+    async def handle_length_alert(self, config, ctx, content) -> None:
         """Method to handle alert for the protect extension."""
-        attachments = []
+        attachments: list[discord.File] = []
         if ctx.message.attachments:
-            attachments = [await attch.to_file() for attch in ctx.message.attachments]
+            total_attachment_size = 0
+            for attch in ctx.message.attachments:
+                if (
+                    total_attachment_size := total_attachment_size + attch.size
+                ) <= ctx.filesize_limit:
+                    attachments.append(await attch.to_file())
+            if (lf := len(ctx.message.attachments) - len(attachments)) != 0:
+                await self.bot.logger.info(
+                    f"Did not reupload {lf} file(s) due to file size limit."
+                )
         await ctx.message.delete()
 
         reason = "message too long (too many newlines or characters)"
 
-        if not self.bot.file_config.main.api_url.linx:
+        if not self.bot.file_config.api.api_url.linx:
             await self.send_default_delete_response(config, ctx, content, reason)
             return
 
@@ -621,7 +630,7 @@ class Protector(base.MatchCog):
         }
         file = {"file": io.StringIO(content)}
         response = await self.bot.http_call(
-            "post", self.bot.file_config.main.api_url.linx, headers=headers, data=file
+            "post", self.bot.file_config.api.api_url.linx, headers=headers, data=file
         )
 
         url = response.get("url")


### PR DESCRIPTION
Protect and Logger will gather attachments from the message until the `filesize_limit` of the channel is reached and ignore any remaining files. A log entry will be made with the number of files not uploaded. Closes #509 

Updated Protect to be compatible with the changes in the structure of `config.yml`.