### PR TITLE
Fix many issues with the role command

### DIFF
--- a/techsupport_bot/extensions/role.py
+++ b/techsupport_bot/extensions/role.py
@@ -267,8 +267,8 @@ class RoleGiver(cogs.BaseCog):
 
         Args:
             config_roles (list[str]): The list of roles allowed to be modified
-            new_roles (list[str]): The list of roles from the config_roles that should be assigned to
-                the user. Any roles not on this list will be removed
+            new_roles (list[str]): The list of roles from the config_roles that should be assigned
+                to the user. Any roles not on this list will be removed
             guild (discord.Guild): The guild to assign the roles in
             user (discord.Member): The member to assign roles to
             resaon (str): The reason to add to the audit log

--- a/techsupport_bot/ui/roleselect.py
+++ b/techsupport_bot/ui/roleselect.py
@@ -28,6 +28,7 @@ class RoleSelect(discord.ui.Select):
         self.view.stop()
 
     async def on_timeout(self):
+        """What happens when the view timesout. This is to prevent all roles from being removed."""
         self.values = None
         self.timeout = True
         self.view.stop()


### PR DESCRIPTION
This makes the role module seem a lot less hastily implemented, with the following major changes:

Adds error handling to the role extension
Removes the drop down box after a selection has been made
Adds a lock to prevent more than 1 person from modifying roles at the same time on the same person
Adds timeout handling to prevent a timeout from removing all roles
Makes confirmation or rejection messages use the confirm/deny embeds
Adds proper type hints to the entire file
Makes final response show what roles were added and removed
Will ensure that a success message isn't shown if it wasn't successful

Fixes #691 