### PR TITLE
Fix factoid fallback in edge cases

### DIFF
--- a/techsupport_bot/commands/factoids.py
+++ b/techsupport_bot/commands/factoids.py
@@ -671,7 +671,11 @@ class FactoidManager(cogs.MatchCog):
         embed = self.get_embed_from_factoid(factoid)
         # if the json doesn't include non embed argument, then don't send anything
         # otherwise send message text with embed
-        plaintext_content = factoid.message if not embed else None
+        try:
+            plaintext_content = factoid.message if not embed else None
+        except ValueError:
+            # The not embed causes a ValueError in certain cases. This ensures fallback works
+            plaintext_content = factoid.message
         mentions = auxiliary.construct_mention_string(ctx.message.mentions)
 
         content = " ".join(filter(None, [mentions, plaintext_content])) or None
@@ -840,7 +844,11 @@ class FactoidManager(cogs.MatchCog):
 
             # Get_embed accepts job as a factoid object
             embed = self.get_embed_from_factoid(factoid)
-            content = factoid.message if not embed else None
+            try:
+                content = factoid.message if not embed else None
+            except ValueError:
+                # The not embed causes a ValueError in certian places. This ensures fallback works
+                content = factoid.message
 
             channel = self.bot.get_channel(int(job.channel))
             if not channel:


### PR DESCRIPTION
A rare edge case where the embed object is created fine, but a `if not embed` causes a ValueError has been fixed.