### PR TITLE
Fix extension load/unload

### DIFF
--- a/techsupport_bot/commands/extension.py
+++ b/techsupport_bot/commands/extension.py
@@ -96,7 +96,7 @@ class ExtensionControl(cogs.BaseCog):
         """
         try:
             await ctx.bot.load_extension(f"functions.{extension_name}")
-        except:
+        except (ModuleNotFoundError, commands.errors.ExtensionNotFound):
             await ctx.bot.load_extension(f"commands.{extension_name}")
         await auxiliary.send_confirm_embed(
             message="I've loaded that extension", channel=ctx.channel
@@ -119,7 +119,7 @@ class ExtensionControl(cogs.BaseCog):
         """
         try:
             await ctx.bot.unload_extension(f"functions.{extension_name}")
-        except:
+        except commands.errors.ExtensionNotLoaded:
             await ctx.bot.unload_extension(f"commands.{extension_name}")
         await auxiliary.send_confirm_embed(
             message="I've unloaded that extension", channel=ctx.channel


### PR DESCRIPTION
This fixes the extension load and unload commands, as they were never changed when extensions was replaced with functions/commands.

This is a kinda hacky fix, a better fix can and should be devised at a later point