### PR TITLE
Make purge not count deleting it's own message

### DIFF
--- a/techsupport_bot/commands/protect.py
+++ b/techsupport_bot/commands/protect.py
@@ -898,7 +898,7 @@ class Protector(cogs.MatchCog):
         if amount <= 0 or amount > config.extensions.protect.max_purge_amount.value:
             amount = config.extensions.protect.max_purge_amount.value
 
-        await ctx.channel.purge(limit=amount)
+        await ctx.channel.purge(limit=amount + 1)
 
         await self.send_alert(config, ctx, "Purge command")
 


### PR DESCRIPTION
This just increases the count by one when calling the actual purge, so that the invocation of purge is counted
Fixes #811 