### PR TITLE
Remove extra 'htd' in htd help (Fixes #832)

### DIFF
--- a/techsupport_bot/commands/htd.py
+++ b/techsupport_bot/commands/htd.py
@@ -128,7 +128,7 @@ class Htd(cogs.BaseCog):
             " encodings (bianary, hex, base 10, and ascii)"
         ),
         usage=(
-            "`htd [value]`\nAccepts numbers in the following formats:\n0x"
+            "`[value]`\nAccepts numbers in the following formats:\n0x"
             " (hex)\n0b (binary) \nNo prefix (assumed ascii)"
         ),
     )


### PR DESCRIPTION
Remove extra 'htd' in htd help (Fixes #832)