### PR TITLE
Fix all flake8 DOC104 issues

### DIFF
--- a/techsupport_bot/commands/factoids.py
+++ b/techsupport_bot/commands/factoids.py
@@ -372,9 +372,9 @@ class FactoidManager(cogs.MatchCog):
         """Changes the list of aliases to point to a new name
 
         Args:
+            ctx (commands.Context): Used for cache handling
             aliases (list): A list of aliases to change
             new_name (str): The name of the new parent
-            ctx (commands.Context): Used for cache handling
         """
 
         for alias in aliases:


### PR DESCRIPTION
DOC104: Arguments are the same in the docstring and the function signature, but are in a different order.

1 issue:
./techsupport_bot/commands/factoids.py:369:1: DOC104 Method `FactoidManager.handle_parent_change`: Arguments are the same in the docstring and the function signature, but are in a different order. 
