### PR TITLE
Fix all flake8 DCO051 issues

### DIFF
--- a/techsupport_bot/commands/modmail.py
+++ b/techsupport_bot/commands/modmail.py
@@ -928,9 +928,6 @@ class Modmail(cogs.BaseCog):
 
         Args:
             message (discord.Message): The sent message
-
-        Raises:
-            commands.MissingAnyRole: When the invoker doesn't have a modmail role
         """
         if (
             not message.content.startswith(self.prefix)


### PR DESCRIPTION
DCO051: function/ method that raises no exceptions and the docstring has a raises section.

1 issue:
./techsupport_bot/commands/modmail.py:927:9: DCO051 a function/ method that does not raise an exception should not have the raises section in the docstring, more information: https://github.com/jdkandersson/flake8-docstrings-complete#fix-dco051