### PR TITLE
Fix all flake8 ANN205 issues

### DIFF
--- a/techsupport_bot/commands/giphy.py
+++ b/techsupport_bot/commands/giphy.py
@@ -25,7 +25,7 @@ class Giphy(cogs.BaseCog):
     SEARCH_LIMIT = 10
 
     @staticmethod
-    def parse_url(url):
+    def parse_url(url: str) -> str:
         """Method to parse the url."""
         index = url.find("?cid=")
         return url[:index]


### PR DESCRIPTION
ANN205: Missing return type annotation for staticmethod

1 issue
./techsupport_bot/commands/giphy.py:28:23: ANN205 Missing return type annotation for staticmethod