### PR TITLE
Fix all flake8 DOC405 issues

### DIFF
--- a/techsupport_bot/tests/helpers/channel.py
+++ b/techsupport_bot/tests/helpers/channel.py
@@ -2,6 +2,8 @@
 This is a file to store the fake disord.TextChannel objection
 """
 
+from typing import AsyncGenerator
+
 
 class MockChannel:
     """
@@ -16,7 +18,7 @@ class MockChannel:
     def __init__(self, history=None):
         self.message_history = history
 
-    async def history(self, limit):
+    async def history(self, limit) -> AsyncGenerator[str, None]:
         """Replication of the async history method
         As history is not expected to be massive, this just yields every message
 
@@ -24,7 +26,7 @@ class MockChannel:
             limit (int): The represents a limit. This is currently not used
 
         Yields:
-            str : This represents a single message in the history
+            AsyncGenerator[str, None, None] : This represents a single message in the history
         """
         if limit == 0:
             return


### PR DESCRIPTION
DOC405: Method has both "return" and "yield" statements. Please use Generator[YieldType, SendType, ReturnType] as the return type annotation, and put your yield type in YieldType and return type in ReturnType. More details in https://jsh9.github.io/pydoclint/notes_generator_vs_iterator.html

1 issue
./techsupport_bot/tests/helpers/channel.py:19:1: DOC405 Method `MockChannel.history` has both "return" and "yield" statements. Please use Generator[YieldType, SendType, ReturnType] as the return type annotation, and put your yield type in YieldType and return type in ReturnType. More details in https://jsh9.github.io/pydoclint/notes_generator_vs_iterator.html 
