### PR TITLE
Fix all flake8 ANN202 issues

### DIFF
--- a/techsupport_bot/commands/factoids.py
+++ b/techsupport_bot/commands/factoids.py
@@ -1338,7 +1338,7 @@ class FactoidManager(cogs.MatchCog):
         description="Gets embed JSON for a factoid",
         usage="[factoid-name]",
     )
-    async def _json(self, ctx: commands.Context, factoid_name: str):
+    async def _json(self, ctx: commands.Context, factoid_name: str) -> None:
         """Gets the json of a factoid
 
         Args:

--- a/techsupport_bot/core/cogs.py
+++ b/techsupport_bot/core/cogs.py
@@ -46,7 +46,7 @@ class BaseCog(commands.Cog):
 
         asyncio.create_task(self._preconfig())
 
-    async def _handle_preconfig(self, handler):
+    async def _handle_preconfig(self, handler) -> None:
         """Wrapper for performing preconfig on an extension.
 
         This makes the extension unload when there is an error.


### PR DESCRIPTION
ANN202: Missing return type annotation for protected function

2 issues
./techsupport_bot/commands/factoids.py:1341:68: ANN202 Missing return type annotation for protected function
./techsupport_bot/core/cogs.py:49:47: ANN202 Missing return type annotation for protected function