### PR TITLE
Fix all flake8 E713 issues

### DIFF
--- a/techsupport_bot/bot.py
+++ b/techsupport_bot/bot.py
@@ -831,7 +831,7 @@ class TechSupportBot(commands.Bot):
             bool: False if disabled, True if enabled
         """
         config = self.guild_configs[str(guild.id)]
-        if not extension_name in config.enabled_extensions:
+        if extension_name not in config.enabled_extensions:
             return False
         return True
 

--- a/techsupport_bot/commands/config.py
+++ b/techsupport_bot/commands/config.py
@@ -180,7 +180,7 @@ class ConfigControl(cogs.BaseCog):
             return
 
         config = self.bot.guild_configs[str(ctx.guild.id)]
-        if not extension_name in config.enabled_extensions:
+        if extension_name not in config.enabled_extensions:
             await auxiliary.send_deny_embed(
                 message="That extension is already disabled for this guild",
                 channel=ctx.channel,

--- a/techsupport_bot/commands/poll.py
+++ b/techsupport_bot/commands/poll.py
@@ -235,7 +235,7 @@ class ReactionPoller(PollGenerator):
                     del voted[user.id]
                     excluded.add(user.id)
 
-                if not user.id in excluded:
+                if user.id not in excluded:
                     try:
                         voted[user.id] = options[option_emojis.index(reaction.emoji)]
                     except ValueError:

--- a/techsupport_bot/commands/relay.py
+++ b/techsupport_bot/commands/relay.py
@@ -299,7 +299,7 @@ class DiscordToIRC(cogs.MatchCog):
 
         joined_channels = getattr(self.bot.file_config.api.irc, "channels")
 
-        if not irc_channel in joined_channels:
+        if irc_channel not in joined_channels:
             await auxiliary.send_deny_embed(
                 message="I am not in that IRC channel", channel=ctx.channel
             )

--- a/techsupport_bot/core/cogs.py
+++ b/techsupport_bot/core/cogs.py
@@ -288,7 +288,7 @@ class LoopCog(BaseCog):
                         )
                         continue
 
-                    if not channel.id in [ch.id for ch in registered_channels]:
+                    if channel.id not in [ch.id for ch in registered_channels]:
                         await self.bot.logger.send_log(
                             message=(
                                 f"Found new channel with ID {channel.id} in loop config"


### PR DESCRIPTION
E713: test for membership should be ‘not in’

5 issues
./techsupport_bot/bot.py:834:12: E713 test for membership should be 'not in'
./techsupport_bot/commands/config.py:183:12: E713 test for membership should be 'not in'
./techsupport_bot/commands/poll.py:238:20: E713 test for membership should be 'not in'
./techsupport_bot/commands/relay.py:302:12: E713 test for membership should be 'not in'
./techsupport_bot/core/cogs.py:291:24: E713 test for membership should be 'not in'