### PR TITLE
Fix all flake8 DOC110 issues

### DIFF
--- a/techsupport_bot/commands/factoids.py
+++ b/techsupport_bot/commands/factoids.py
@@ -236,7 +236,7 @@ class FactoidManager(cogs.MatchCog):
             embed_config (str): Whether the factoid has an embed set up
             alias (str, optional): The parent factoid. Defaults to None.
 
-            Raises:
+        Raises:
             custom_errors.TooLongFactoidMessageError:
                 When the message argument is over 2k chars, discords limit
         """
@@ -433,11 +433,11 @@ class FactoidManager(cogs.MatchCog):
 
         return False
 
-    def get_embed_from_factoid(self, factoid) -> discord.Embed:
+    def get_embed_from_factoid(self, factoid: bot.models.Factoid) -> discord.Embed:
         """Gets the factoid embed from its message.
 
         Args:
-            (Factoid) factoid: The factoid to get the json of
+            factoid (bot.models.Factoid): The factoid to get the json of
 
         Returns:
             discord.Embed: The embed of the factoid

--- a/techsupport_bot/commands/modmail.py
+++ b/techsupport_bot/commands/modmail.py
@@ -20,6 +20,7 @@ from typing import TYPE_CHECKING, Tuple
 
 import discord
 import expiringdict
+import munch
 import ui
 from core import auxiliary, cogs, extensionconfig
 from discord.ext import commands
@@ -28,13 +29,15 @@ if TYPE_CHECKING:
     import bot
 
 
-async def has_modmail_management_role(ctx: commands.Context, config=None) -> bool:
+async def has_modmail_management_role(
+    ctx: commands.Context, config: munch.Munch = None
+) -> bool:
     """-COMMAND CHECK-
     Checks if the invoker has a modmail management role
 
     Args:
         ctx (commands.Context): Context used for getting the config file
-        config (): Can be defined manually to run this without providing actual ctx
+        config (munch.Munch): Can be defined manually to run this without providing actual ctx
 
     Raises:
         commands.CommandError: No modmail management roles were assigned in the config


### PR DESCRIPTION
DOC110: The option --arg-type-hints-in-docstring is True but not all args in the docstring arg list have type hints

3 issues
./techsupport_bot/commands/factoids.py:222:1: DOC110 Method `FactoidManager.create_factoid_call`: The option `--arg-type-hints-in-docstring` is `True` but not all args in the docstring arg list have type hints 
./techsupport_bot/commands/factoids.py:436:1: DOC110 Method `FactoidManager.get_embed_from_factoid`: The option `--arg-type-hints-in-docstring` is `True` but not all args in the docstring arg list have type hints 
./techsupport_bot/commands/modmail.py:31:1: DOC110 Function `has_modmail_management_role`: The option `--arg-type-hints-in-docstring` is `True` but not all args in the docstring arg list have type hints