### PR TITLE
Fix all flake8 DOC102 issues

### DIFF
--- a/techsupport_bot/commands/factoids.py
+++ b/techsupport_bot/commands/factoids.py
@@ -700,7 +700,6 @@ class FactoidManager(cogs.MatchCog):
 
         Args:
             config (Config): The config to get the prefix from
-            _ (commands.Context): Ctx, not used
             message_contents (str): The message to check
 
         Returns:
@@ -715,7 +714,6 @@ class FactoidManager(cogs.MatchCog):
             config (Config): The server config
             ctx (commands.Context): Context of the call
             message_content (str): Content of the call
-            _ (bool): Result, unused
 
         Raises:
             custom_errors.FactoidNotFoundError: Raised if a broken alias is present in the DB

--- a/techsupport_bot/commands/modmail.py
+++ b/techsupport_bot/commands/modmail.py
@@ -135,7 +135,6 @@ class Modmail_bot(discord.Client):
         Args:
             channel (discord.Channel): The channel where someone started typing
             user (discord.User): The user who started typing
-            _ (datetime.datetime): The timestamp of when typing started, unused
         """
         if isinstance(channel, discord.DMChannel) and user.id in active_threads:
             await self.get_channel(active_threads[user.id]).typing()

--- a/techsupport_bot/functions/autoreact.py
+++ b/techsupport_bot/functions/autoreact.py
@@ -1,6 +1,8 @@
 """Module for the autoreact extension for the discord bot."""
 
+import munch
 from core import auxiliary, cogs, extensionconfig
+from discord.ext import commands
 
 
 async def setup(bot):
@@ -21,12 +23,13 @@ async def setup(bot):
 class AutoReact(cogs.MatchCog):
     """Class for the autoreact to make it to discord."""
 
-    async def match(self, config, _, content):
+    async def match(
+        self, config: munch.Munch, _: commands.Context, content: str
+    ) -> bool:
         """A match function to determine if somehting should be reacted to
 
         Args:
             config (munch.Munch): The guild config for the running bot
-            _ (commands.Context): The context in which the message was sent in
             content (str): The string content of the message
 
         Returns:
@@ -39,14 +42,15 @@ class AutoReact(cogs.MatchCog):
                 return True
         return False
 
-    async def response(self, config, ctx, content, _):
+    async def response(
+        self, config: munch.Munch, ctx: commands.Context, content: str, _: bool
+    ):
         """The function to generate and add reactions
 
         Args:
             config (munch.Munch): The guild config for the running bot
             ctx (commands.Context): The context in which the message was sent in
             content (str): The string content of the message
-            _ (bool): The result from the match function
         """
         search_content = f" {content} "
         search_content = search_content.lower()

--- a/techsupport_bot/ircrelay/irc.py
+++ b/techsupport_bot/ircrelay/irc.py
@@ -82,7 +82,6 @@ class IRCBot(ib3.auth.SASL, irc.bot.SingleServerIRCBot):
 
         Args:
             connection (irc.client.ServerConnection): The IRC connection
-            _ (irc.client.Event): The event object that triggered this function
         """
         connection.nick(connection.get_nickname() + "_")
 
@@ -95,7 +94,6 @@ class IRCBot(ib3.auth.SASL, irc.bot.SingleServerIRCBot):
 
         Args:
             connection (irc.client.ServerConnection): The IRC connection
-            _ (irc.client.Event): The event object that triggered this function
         """
         self.console.info("Connected to IRC")
         self.ready = True
@@ -143,7 +141,6 @@ class IRCBot(ib3.auth.SASL, irc.bot.SingleServerIRCBot):
         Currently just sends a message to the discord bot owners DMs
 
         Args:
-            _ (irc.client.ServerConnection): The IRC connection
             event (irc.client.Event): The event object that triggered this function
         """
         asyncio.run_coroutine_threadsafe(
@@ -158,7 +155,6 @@ class IRCBot(ib3.auth.SASL, irc.bot.SingleServerIRCBot):
         If the channel is linked to a discord channel, the message will get sent to discord
 
         Args:
-           _ (irc.client.ServerConnection): The IRC connection
            event (irc.client.Event): The event object that triggered this function
         """
         split_message = formatting.parse_irc_message(event=event)
@@ -272,7 +268,6 @@ class IRCBot(ib3.auth.SASL, irc.bot.SingleServerIRCBot):
         Currently just handles ban notifications
 
         Args:
-            _ (irc.client.ServerConnection): The IRC connection
             event (irc.client.Event): The event object that triggered this function
         """
         # Parse the mode change event


### PR DESCRIPTION
DOC102: Docstring contains more arguments than in function signature

10 issues
./techsupport_bot/commands/factoids.py:698:1: DOC102 Method `FactoidManager.match`: Docstring contains more arguments than in function signature. 
./techsupport_bot/commands/factoids.py:711:1: DOC102 Method `FactoidManager.response`: Docstring contains more arguments than in function signature. 
./techsupport_bot/commands/modmail.py:130:1: DOC102 Method `Modmail_bot.on_typing`: Docstring contains more arguments than in function signature. 
./techsupport_bot/functions/autoreact.py:24:1: DOC102 Method `AutoReact.match`: Docstring contains more arguments than in function signature. 
./techsupport_bot/functions/autoreact.py:42:1: DOC102 Method `AutoReact.response`: Docstring contains more arguments than in function signature. 
./techsupport_bot/ircrelay/irc.py:78:1: DOC102 Method `IRCBot.on_nicknameinuse`: Docstring contains more arguments than in function signature. 
./techsupport_bot/ircrelay/irc.py:89:1: DOC102 Method `IRCBot.on_welcome`: Docstring contains more arguments than in function signature. 
./techsupport_bot/ircrelay/irc.py:139:1: DOC102 Method `IRCBot.on_privmsg`: Docstring contains more arguments than in function signature. 
./techsupport_bot/ircrelay/irc.py:154:1: DOC102 Method `IRCBot.on_pubmsg`: Docstring contains more arguments than in function signature. 
./techsupport_bot/ircrelay/irc.py:270:1: DOC102 Method `IRCBot.on_mode`: Docstring contains more arguments than in function signature.