### PR TITLE
Ducks don't timeout anymore

### DIFF
--- a/techsupport_bot/commands/duck.py
+++ b/techsupport_bot/commands/duck.py
@@ -380,17 +380,7 @@ class DuckHunt(cogs.LoopCog):
                     f"seconds. Time would have been {duration_exact} seconds"
                 )
             )
-            # Only attempt timeout if we know we can do it
-            if (
-                channel.guild.me.top_role > message.author.top_role
-                and channel.guild.me.guild_permissions.moderate_members
-            ):
-                asyncio.create_task(
-                    message.author.timeout(
-                        timedelta(seconds=config.extensions.duck.cooldown.value),
-                        reason="Missed a duck",
-                    )
-                )
+
             asyncio.create_task(
                 message.channel.send(
                     content=message.author.mention,


### PR DESCRIPTION
Timeouts add an unfair advantage for moderators, since discord takes a few seconds to register the timeout ending. On mobile it's far more than 5 seconds as well, since discord doesn't let you type in a channel after being untimed out; you need to switch to another one to get rid of the "Done reading? Check out \#channel" message.