### PR TITLE
Joke configs

### DIFF
--- a/techsupport_bot/commands/joke.py
+++ b/techsupport_bot/commands/joke.py
@@ -38,8 +38,8 @@ async def setup(bot: bot.TechSupportBot) -> None:
         description=(
             "Toggles whether or not filters are applies in NSFW channels"
         ),
-    )
         default=False,
+    )
     await bot.add_cog(Joker(bot=bot))
     bot.add_extension_config("joke", config)
 

--- a/techsupport_bot/commands/joke.py
+++ b/techsupport_bot/commands/joke.py
@@ -19,17 +19,28 @@ async def setup(bot: bot.TechSupportBot) -> None:
     Args:
         bot (bot.TechSupportBot): The bot object to register the cogs to
     """
+
     config = extensionconfig.ExtensionConfig()
     config.add(
-        key="pc_jokes",
-        datatype="bool",
-        title="Politically correct jokes only",
+        key="blacklisted_filters",
+        datatype="list[str]",
+        title="Enable filter",
         description=(
-            "True only politically correct jokes should be shown"
-            " (non-racist/non-sexist)"
+            "Filters all categories listed"
+            "(nsfw,religious,political,racist,sexist,explicit)"
         ),
-        default=True,
+        default=["nsfw","explicit"],
     )
+    
+    config = extensionconfig.ExtensionConfig()
+    config.add(
+        key="apply_in_nsfw_channels",
+        datatype="bool",
+        title="Apply in NSFW Channels",
+        description=(
+            "Toggles whether or not filters are applies in NSFW channels"
+        ),
+        default=False,
     await bot.add_cog(Joker(bot=bot))
     bot.add_extension_config("joke", config)
 
@@ -75,10 +86,8 @@ class Joker(cogs.BaseCog):
             str: The URL, properly formatted and ready to be called
         """
         blacklist_flags = []
-        if not ctx.channel.is_nsfw():
-            blacklist_flags.extend(["explicit", "nsfw"])
-        if config.extensions.joke.pc_jokes.value:
-            blacklist_flags.extend(["sexist", "racist", "religious"])
+        if apply_in_nsfw_channels or not ctx.channel.is_nsfw():
+            blacklist_flags = config.blacklisted_filters
         blacklists = ",".join(blacklist_flags)
 
         url = f"{self.API_URL}?blacklistFlags={blacklists}&format=txt"

--- a/techsupport_bot/commands/joke.py
+++ b/techsupport_bot/commands/joke.py
@@ -31,8 +31,6 @@ async def setup(bot: bot.TechSupportBot) -> None:
         ),
         default=["nsfw","explicit"],
     )
-    
-    config = extensionconfig.ExtensionConfig()
     config.add(
         key="apply_in_nsfw_channels",
         datatype="bool",
@@ -40,6 +38,7 @@ async def setup(bot: bot.TechSupportBot) -> None:
         description=(
             "Toggles whether or not filters are applies in NSFW channels"
         ),
+    )
         default=False,
     await bot.add_cog(Joker(bot=bot))
     bot.add_extension_config("joke", config)
@@ -86,8 +85,8 @@ class Joker(cogs.BaseCog):
             str: The URL, properly formatted and ready to be called
         """
         blacklist_flags = []
-        if apply_in_nsfw_channels or not ctx.channel.is_nsfw():
-            blacklist_flags = config.blacklisted_filters
+        if config.extensions.joke.apply_in_nsfw_channels.value or not ctx.channel.is_nsfw():
+            blacklist_flags = config.extensions.joke.blacklisted_filters.value
         blacklists = ",".join(blacklist_flags)
 
         url = f"{self.API_URL}?blacklistFlags={blacklists}&format=txt"


### PR DESCRIPTION
Adds a dynamic config for the joke function, allowing ant filter or group of filters to be applied without having to restart the bot, as well as adding an new config which toggles if the joke filter is applied when in an NSFW channel.

This has also deleted the “Politically correct” filter due to it becoming redundant with the new dynamic config added.