### PR TITLE
Fix modmail alias command when no aliases defined

### DIFF
--- a/techsupport_bot/commands/modmail.py
+++ b/techsupport_bot/commands/modmail.py
@@ -1386,6 +1386,9 @@ class Modmail(cogs.BaseCog):
                 description="There are no aliases registered for this guild",
             )
 
+            await ctx.channel.send(embed=embed)
+            return
+
         embed = discord.Embed(
             color=discord.Color.green(), title="Registered aliases for this guild:"
         )


### PR DESCRIPTION
Fix modmail alias command when no aliases defined
Fixes #1285 

*In hindsight I should have just put this with my other modmail PR*