### PR TITLE
Does better factoid fallback management for failed embed

### DIFF
--- a/techsupport_bot/commands/factoids.py
+++ b/techsupport_bot/commands/factoids.py
@@ -1198,7 +1198,9 @@ class FactoidManager(cogs.MatchCog):
                 except TypeError as exception:
                     log_channel = config.get("logging_channel")
                     await self.bot.logger.send_log(
-                        message=f"Unable to make embed for factoid `{factoid.name}`, sending fallback.",
+                        message=(
+                            f"Unable to make embed for factoid `{factoid.name}`, sending fallback."
+                        ),
                         level=LogLevel.ERROR,
                         channel=log_channel,
                         context=LogContext(guild=channel.guild, channel=channel),


### PR DESCRIPTION
Fixes #1180 
Adds a try catch to address fallback issues if there is a TypeError when creating the embed in factoids.

All 3 ways of calling a factoid have been changed, and will need testing, including the disable_embeds config option.