### PR TITLE
Fix many bugs in recent changes

### DIFF
--- a/techsupport_bot/commands/config.py
+++ b/techsupport_bot/commands/config.py
@@ -279,9 +279,11 @@ class ConfigControl(cogs.BaseCog):
         Args:
             interaction (discord.Interaction): The interaction that triggered the slash command
         """
+        await interaction.response.defer()
         view = ui.Confirm()
         await view.send(
             message=f"Are you sure you want to reset the config for {interaction.guild.name}?",
+            channel=interaction.channel,
             author=interaction.user,
             interaction=interaction,
         )
@@ -303,4 +305,4 @@ class ConfigControl(cogs.BaseCog):
         embed = auxiliary.prepare_confirm_embed(
             message="I've reset the config for this guild"
         )
-        view.followup.send(embed=embed)
+        await view.followup.send(embed=embed)

--- a/techsupport_bot/commands/dictionary.py
+++ b/techsupport_bot/commands/dictionary.py
@@ -66,15 +66,21 @@ class Dictionary(cogs.BaseCog):
         response = await self.bot.http_functions.http_call("get", url)
         if not response:
             embed = auxiliary.prepare_deny_embed(
-                f"I could not find any definition for `{word}`"
+                f"I could not find any information for `{word}`"
             )
             await interaction.followup.send(embed=embed)
             return
 
-        definition = response[0].shortdef
-
-        embed = discord.Embed(title=f"Definition of `{word}`")
-        embed.color = discord.Color.orange()
-        embed.description = "\n".join(f"- {string}" for string in definition)
+        try:
+            definition = response[0].shortdef
+            embed = discord.Embed(title=f"Definition of `{word}`")
+            embed.color = discord.Color.orange()
+            embed.description = "\n".join(f"- {string}" for string in definition)
+        except AttributeError:
+            embed = discord.Embed(
+                title=f"The word `{word}` was not found. Did you mean:"
+            )
+            embed.description = ", ".join(response)
+            embed.color = discord.Color.orange()
 
         await interaction.followup.send(embed=embed)

--- a/techsupport_bot/commands/duck.py
+++ b/techsupport_bot/commands/duck.py
@@ -899,7 +899,7 @@ class DuckHunt(cogs.LoopCog):
         spawn_user = configuration.get_config_entry(ctx.guild.id, "duck_spawn_user")
         for person in spawn_user:
             if ctx.author.id == int(person):
-                await self.execute(ctx.guild, ctx.channel)
+                await self.execute(ctx.guild, ctx.channel, ctx.author)
                 return
         await auxiliary.send_deny_embed(
             message="It looks like you don't have permissions to spawn a duck",

--- a/techsupport_bot/commands/extension.py
+++ b/techsupport_bot/commands/extension.py
@@ -211,11 +211,12 @@ class ExtensionControl(cogs.BaseCog):
             extension_name (str): the name of the extension
             extension_file (discord.Attachment): The python file of the extension
         """
+        await interaction.response.defer()
         if not extension_file.filename.endswith(".py"):
             embed = auxiliary.prepare_deny_embed(
                 message="I don't recognize your upload as a Python file",
             )
-            await interaction.response.send_message(embed=embed)
+            await interaction.followup.send(embed=embed)
             return
 
         if extension_name.lower() in await self.bot.get_potential_extensions():

--- a/techsupport_bot/commands/extension.py
+++ b/techsupport_bot/commands/extension.py
@@ -224,6 +224,7 @@ class ExtensionControl(cogs.BaseCog):
             await view.send(
                 message=f"Warning! This will replace the current `{extension_name}.py` "
                 + "extension! Are you SURE?",
+                channel=interaction.channel,
                 author=interaction.user,
                 interaction=interaction,
             )
@@ -240,10 +241,10 @@ class ExtensionControl(cogs.BaseCog):
 
         fp = await extension_file.read()
         await self.bot.register_file_extension(extension_name, fp)
-        embed = auxiliary.send_confirm_embed(
+        embed = auxiliary.prepare_confirm_embed(
             message="I've registered that extension. You can now try loading it",
         )
-        await view.followup.send(embed=embed)
+        await interaction.followup.send(embed=embed)
         return
 
     async def does_extension_exist(self: Self, extension_name: str) -> bool:

--- a/techsupport_bot/commands/factoids.py
+++ b/techsupport_bot/commands/factoids.py
@@ -1028,6 +1028,8 @@ class FactoidManager(cogs.MatchCog):
             content = factoid.message
 
         if member_to_ping:
+            if not content:
+                content = ""
             content = f"{member_to_ping.mention} {content}".strip()
 
         if content and len(content) > 2000:

--- a/techsupport_bot/commands/relay.py
+++ b/techsupport_bot/commands/relay.py
@@ -411,6 +411,8 @@ class DiscordToIRC(cogs.MatchCog):
 
         if "automod" in configuration.get_config_entry(
             discord_channel.guild.id, "core_enabled_extensions"
+        ) and str(discord_channel.id) in configuration.get_config_entry(
+            discord_channel.guild.id, "automod_channels"
         ):
             automod_actions = automod.run_only_string_checks(
                 discord_channel.guild, split_message["content"]

--- a/techsupport_bot/commands/search.py
+++ b/techsupport_bot/commands/search.py
@@ -46,7 +46,7 @@ class WebSearcher(cogs.BaseCog):
         name="search", description="Command Group for the Search Extension"
     )
 
-    async def make_reqest(self: Self, query: str) -> munch.Munch:
+    async def make_request(self: Self, query: str) -> munch.Munch:
         """This functions make a request to the Tavily API
         This pulls the API key from the config and returns a munch.Munch result
 
@@ -94,7 +94,7 @@ class WebSearcher(cogs.BaseCog):
             query (str): The string query passed in by the user
         """
         await interaction.response.defer()
-        response = self.make_request(query)
+        response = await self.make_request(query)
 
         embeds = []
 
@@ -134,7 +134,7 @@ class WebSearcher(cogs.BaseCog):
             query (str): The string query passed in by the user
         """
         await interaction.response.defer()
-        response = self.make_request(query)
+        response = await self.make_request(query)
 
         embeds = []
 

--- a/techsupport_bot/configuration/config.default.json
+++ b/techsupport_bot/configuration/config.default.json
@@ -82,7 +82,7 @@
     "modmail_modmail_roles": [],
     "modmail_roles_to_ping": [],
     "modmail_thread_creation_message": "Create modmail thread?",
-    "news_category": "",
+    "news_category": "general",
     "news_channel": "",
     "news_country": "US",
     "news_cron_config": "0 17 * * *",

--- a/techsupport_bot/core/cogs.py
+++ b/techsupport_bot/core/cogs.py
@@ -342,10 +342,11 @@ class LoopCog(BaseCog):
                 if guild and guild not in self.bot.guilds:
                     break
 
-                channels_list = configuration.get_config_entry(
-                    guild.id, self.CHANNELS_KEY
-                )
-                if not channels_list:
+                try:
+                    channels_list = configuration.get_config_entry(
+                        guild.id, self.CHANNELS_KEY
+                    )
+                except AttributeError:
                     channels_list = []
 
                 if target_channel and str(target_channel.id) not in channels_list:

--- a/techsupport_bot/functions/autoreact.py
+++ b/techsupport_bot/functions/autoreact.py
@@ -60,5 +60,5 @@ class AutoReact(cogs.MatchCog):
             if f" {word.lower()} " in search_content:
                 reaction = reaction_map.get(word)
                 if reaction not in reactions:
-                    reactions.append(reaction_map.value.get(word))
+                    reactions.append(reaction_map.get(word))
         await auxiliary.add_list_of_reactions(message=ctx.message, reactions=reactions)


### PR DESCRIPTION
- Fixes a bug with LoopCog on non channel specific loops
- Defer response on config reset and extension register commands
- Add missing await statement in config reset
- Properly handles dictionary API for suggested words on small misspellings
- Fixes bug with duck spawn adding banned user to spawner (OLD)
- Rename function in /extension register
- Add missing parameter in confirmation in register command
- Make response actually work in register command
- Fix bug where factoid call would say none if pinging a member with an embed
- Fix bug where IRC auto mod did not check if channels protected by auto mod or not (OLD)
- Fix bug where news category config default didn't work
- Update calling to make_request to be await
- Fix spelling error in make_request function name
- Fix a small bug with the new config system in autoreact