### PR TITLE
Removes the status field from whois

### DIFF
--- a/modules/moderation/whois.py
+++ b/modules/moderation/whois.py
@@ -59,9 +59,6 @@ class Whois(cogs.BaseCog):
             name="Created", value=f"<t:{int(member.created_at.timestamp())}>"
         )
         embed.add_field(name="Joined", value=f"<t:{int(member.joined_at.timestamp())}>")
-        embed.add_field(
-            name="Status", value=interaction.guild.get_member(member.id).status
-        )
         embed.add_field(name="Nickname", value=member.display_name)
 
         role_list = member.roles[1:]


### PR DESCRIPTION
As the bot will lose access to the status information due to discords decisions on privileged intents, this has to be removed.

Fixes #1556 